### PR TITLE
Add "ready" to bootmarker.

### DIFF
--- a/examples/webclient/webclient.ino
+++ b/examples/webclient/webclient.ino
@@ -43,7 +43,7 @@ void setup() {
   // by providing a string to ID the tail end of the boot message:
   
   // comment/replace this if you are using something other than v 0.9.2.4!
-  wifi.setBootMarker(F("Version:0.9.2.4]\r\n"));
+  wifi.setBootMarker(F("Version:0.9.2.4]\r\n\r\nready"));
 
   softser.begin(9600); // Soft serial connection to ESP8266
   Serial.begin(57600); while(!Serial); // UART serial debug


### PR DESCRIPTION
Otherwise, the module may reset if you send it another command before the reset completes (and the "ready" prints). I was seeing the ATE0 command (disable echo) getting sent before the module finished resetting, which seemed to trigger another reset. The module would then print another boot message, but not the "OK" that the library was expecting as the result of the ATE0 command.