### PR TITLE
Converting URL parameter to const char. It is more convenient to use …

### DIFF
--- a/Adafruit_ESP8266.cpp
+++ b/Adafruit_ESP8266.cpp
@@ -255,7 +255,7 @@ boolean Adafruit_ESP8266::requestURL(Fstr *url) {
 // else false.  Calling function should then handle data returned, may
 // need to parse IPD delimiters (see notes in find() function.
 // (Can call find(F("Unlink"), true) to dump to debug.)
-boolean Adafruit_ESP8266::requestURL(char* url) {
+boolean Adafruit_ESP8266::requestURL(const char* url) {
     print(F("AT+CIPSEND="));
     println(25 + strlen(url) + strlen_P((Pchr *)host));
     if(find(F("> "))) { // Wait for prompt

--- a/Adafruit_ESP8266.h
+++ b/Adafruit_ESP8266.h
@@ -40,7 +40,7 @@ class Adafruit_ESP8266 : public Print {
             connectToAP(Fstr *ssid, Fstr *pass),
             connectTCP(Fstr *host, int port),
             requestURL(Fstr *url),
-            requestURL(char* url);
+            requestURL(const char* url);
   int       readLine(char *buf, int bufSiz);
   void      closeAP(void),
             closeTCP(void),


### PR DESCRIPTION
…it if the url is being constructed with the String class, 

like: 
`String a = "api.wxy.com/update?t=" + someVar;
const char* url = a.c_str().`

That returns a const char*.
